### PR TITLE
Use legal docker tag characters

### DIFF
--- a/.github/workflows/gh-cd.yml
+++ b/.github/workflows/gh-cd.yml
@@ -29,7 +29,7 @@ jobs:
         IMAGE_ID=$DOCKER_ORG/$IMAGE_NAME
         BASE_VERSION=$(docker run temp-image python -c "import coffea; print(coffea.__version__)")
         BUILD=$(git rev-parse --short HEAD)
-        VERSION=${BASE_VERSION}+g${BUILD}
+        VERSION=${BASE_VERSION}-g${BUILD}
 
         echo IMAGE_ID=$IMAGE_ID
         echo VERSION=$VERSION


### PR DESCRIPTION
Apparently docker tags cannot have `+`, meanwhile there are many requests to support at least semantic version tags:
https://github.com/opencontainers/distribution-spec/issues/154﻿
Maybe someday we can use plus, for now it seems `-` is allowed
