### PR TITLE
Adding dask-gateway compatible image

### DIFF
--- a/dask-cc7-gateway/Dockerfile
+++ b/dask-cc7-gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM coffeateam/coffea-dask:latest
+FROM coffeateam/coffea-base-cc7:0.7.7-fastjet-3.3.4.0rc9
 
 # Relevant for dask-gateway compatibility
 RUN conda install --yes \

--- a/dask-cc7-gateway/Dockerfile
+++ b/dask-cc7-gateway/Dockerfile
@@ -1,0 +1,16 @@
+FROM coffeateam/coffea-dask:latest
+
+# Relevant for dask-gateway compatibility
+RUN conda install --yes \
+      -c conda-forge \
+      conda-build \
+      dask==2.30.0 \
+      distributed==2.30.1 \
+      dask-gateway==0.9.0 \
+      cloudpickle==1.6.0 \
+      tornado==6.1 \
+      toolz==0.11.1 \
+      numpy==1.19.2 \
+      dask-jobqueue \
+      && conda clean --all -f -y \
+      && conda build purge-all

--- a/dask-cc7-gateway/README.md
+++ b/dask-cc7-gateway/README.md
@@ -1,0 +1,5 @@
+This Dockerfile forces downgrade to a list of packages required by dask-gateway to function properly with out-of-the-box images for the dask-gateway-api server. We are aware that these versions are very outdated and will be maintaining them only in order to avoid incompatibility issues with the current deployment of dask-gateway at FNAL.
+
+It is solely a forced conda downgrade on a number of package versions required by the current dask-gateway images published in DockerHub: https://hub.docker.com/r/daskgateway/dask-gateway-server/tags?page=1&ordering=last_updated
+
+This will hopefully produce a functional image between the latest possible coffea-dask-cc-7 with the pinned packages in downgraded versions.


### PR DESCRIPTION
This PR includes a new separate folder for a coffea-dask image compatible with dask-gateway API servers running on upstream Dask DockerHub images and Helm charts.