### PR TITLE
Pin htcondor to 9.2.0

### DIFF
--- a/dask-cc7/Dockerfile
+++ b/dask-cc7/Dockerfile
@@ -15,7 +15,7 @@ RUN mamba install --yes \
       scipy==1.5.3 \
       tini==0.18.0 \
       jupyter-server-proxy \
-      htcondor \
+      htcondor==9.2.0 \
       && mamba clean -tipsy
 
 ENTRYPOINT ["tini", "-g", "--"]

--- a/dask/Dockerfile
+++ b/dask/Dockerfile
@@ -15,7 +15,7 @@ RUN mamba install --yes \
       scipy==1.5.3 \
       tini==0.18.0 \
       jupyter-server-proxy \
-      htcondor \
+      htcondor==9.2.0 \
       && mamba clean -tipsy
 
 ENTRYPOINT ["tini", "-g", "--"]


### PR DESCRIPTION
Issue with htcondor at lpc, pin to 9.2.0 python bindings for now.