### PR TITLE
feat: Add /opt/conda mount point for Singularity

### DIFF
--- a/dask-cc7-gateway/Dockerfile
+++ b/dask-cc7-gateway/Dockerfile
@@ -17,3 +17,6 @@ RUN mamba install --yes \
       dask-gateway==2022.10.0\
       dask-jobqueue \
       && mamba clean --all --yes
+
+# Add mount point for Singularity/Apptainer
+RUN mkdir -p /opt/conda

--- a/dask-cc7/Dockerfile
+++ b/dask-cc7/Dockerfile
@@ -18,4 +18,7 @@ RUN mamba install --yes \
       htcondor==9.2.0 \
       && mamba clean --yes --all
 
+# Add mount point for Singularity/Apptainer
+RUN mkdir -p /opt/conda
+
 ENTRYPOINT ["tini", "-g", "--"]

--- a/dask/Dockerfile
+++ b/dask/Dockerfile
@@ -18,4 +18,7 @@ RUN mamba install --yes \
       htcondor==9.2.0 \
       && mamba clean --all --yes
 
+# Add mount point for Singularity/Apptainer
+RUN mkdir -p /opt/conda
+
 ENTRYPOINT ["tini", "-g", "--"]


### PR DESCRIPTION
* `/opt/conda` needs to be explicitly created for Singularity to mount it correctly.

Reference:
* https://gitlab.cern.ch/aml/containers/docker/-/merge_requests/25
* https://atlas-talk.sdcc.bnl.gov/t/how-to-activate-python-virtual-environments-with-custom-images/269