### PR TITLE
Revert "Update Dask & Distributed version to 2023.9.1"

### DIFF
--- a/dask-cc7/Dockerfile
+++ b/dask-cc7/Dockerfile
@@ -9,8 +9,8 @@ RUN mamba install --yes \
       python-blosc \
       cytoolz \
       bokeh==2.4.3 \
-      dask==2023.9.1 \
-      distributed==2023.9.1 \
+      dask==2023.3.1 \
+      distributed==2023.3.1 \
       dask-gateway==0.9.0 \
       dask-jobqueue \
       nomkl \

--- a/dask/Dockerfile
+++ b/dask/Dockerfile
@@ -9,8 +9,8 @@ RUN mamba install --yes \
       python-blosc \
       cytoolz \
       bokeh==2.4.3 \
-      dask==2023.9.1 \
-      distributed==2023.9.1 \
+      dask==2023.3.1 \
+      distributed==2023.3.1 \
       dask-gateway==0.9.0 \
       dask-jobqueue \
       nomkl \


### PR DESCRIPTION
Reverts CoffeaTeam/docker-coffea-dask#135

CI is broken with this PR, I will recheck manually and revert back.